### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "http-parser"
+description := "Zero-dependency parser for HTTP messages."
+gitrepo     := "https://github.com/nodejs/http-parser.git"
+homepage    := "https://github.com/nodejs/http-parser/"
+version     := 2.9.4 sha256:467b9e30fd0979ee301065e70f637d525c28193449e1b13fbcb1b1fab3ad224f https://github.com/nodejs/http-parser/archive/v2.9.4.tar.gz
+license     := "MIT"


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

